### PR TITLE
Refactor value formatting using `match` expression

### DIFF
--- a/.github/workflows/back-end.yml
+++ b/.github/workflows/back-end.yml
@@ -21,14 +21,14 @@ env:
 jobs:
     syntax_errors:
         name: "Syntax errors"
-        runs-on: "ubuntu-22.04"
+        runs-on: "ubuntu-24.04"
         timeout-minutes: 1
         steps:
         -
             name: "Set up PHP"
             uses: "shivammathur/setup-php@v2"
             with:
-                php-version: "7.4"
+                php-version: "8.1"
                 coverage: "none"
                 tools: "parallel-lint"
         -

--- a/debug/wp-cli-run-frontend.php
+++ b/debug/wp-cli-run-frontend.php
@@ -15,13 +15,12 @@ add_action(
         $args = func_get_args();
         $hook_name = $args[0];
         $value = isset($args[1]) ? $args[1] : null;
-        $formatted_value = (is_string($value) || is_numeric($value))
-            ? $value
-            : '<'.(is_object($value)
-                ? get_class($value)
-                : (is_bool($value)
-                    ? ($value ? 'TRUE' : 'FALSE')
-                    : gettype($value))).'>';
+        $formatted_value = match (true) {
+            is_string($value) || is_numeric($value) => $value,
+            is_object($value) => '<'.get_class($value).'>',
+            is_bool($value) => $value ? '<TRUE>' : '<FALSE>',
+            default => '<'.gettype($value).'>'
+        };
         printf("%s=%s\n", $hook_name, $formatted_value);
     },
     PHP_INT_MAX,


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored value formatting in debug/wp-cli-run-frontend.php to use a PHP 8.1 match expression and updated CI to run syntax checks on Ubuntu 24.04 with PHP 8.1. Output is unchanged: strings/numbers print as-is; objects, booleans, and other types are wrapped in angle brackets.

<sup>Written for commit d7db6b46ade0b1d12557bf29c6095416b3abd93e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



