### PR TITLE
Add WP_REDIS_DEFAULT_EXPIRE_SECONDS definition

### DIFF
--- a/wp-config/wp-config.php
+++ b/wp-config/wp-config.php
@@ -120,6 +120,7 @@ $redis_server = [
     'database' => 0,
 ];
 define('WP_CACHE_KEY_SALT', 'SITE-SHORT:');
+define('WP_REDIS_DEFAULT_EXPIRE_SECONDS', 86400);
 // disable-updates.php
 define('ENABLE_FORCE_CHECK_UPDATE', true);
 // Performance Lab


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set WP_REDIS_DEFAULT_EXPIRE_SECONDS to 86400 to enforce a 24-hour default TTL for Redis cache entries. This standardizes cache expiry across environments and helps control memory usage.

<sup>Written for commit cd6780f442dd6f2484b7f13ade612adeac31d570. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

