### PR TITLE
Log failed Action Scheduler actions

### DIFF
--- a/mu-plugins/woocommerce.php
+++ b/mu-plugins/woocommerce.php
@@ -222,3 +222,18 @@ add_action(
     10,
     0
 );
+
+// Log failed AS actions
+add_action(
+    'action_scheduler_failed_execution',
+    static function ($action_id, $e, $context) {
+        error_log(sprintf(
+            '[AS FAILED] action_id=%d context=%s error=%s',
+            $action_id,
+            (string) $context,
+            $e instanceof \Exception ? $e->getMessage() : 'unknown'
+        ));
+    },
+    10,
+    3
+);


### PR DESCRIPTION
Add logging for failed Action Scheduler executions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds logging for failed Action Scheduler executions to make background job failures easier to spot and debug. On failure, we write the action_id, context, and exception message to the PHP error log.

<sup>Written for commit 61fa8ecc84b469a92d5a7079e26998a6ad3219f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

