### PR TITLE
Implement trailing slash for no-dot paths

### DIFF
--- a/mu-plugins/_core-auto-trailing-slash.php
+++ b/mu-plugins/_core-auto-trailing-slash.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Plugin Name: Trailing slash for no-dot paths
+ * Plugin URI: https://github.com/szepeviktor/wordpress-website-lifecycle
+ */
+
+add_filter(
+    'mod_rewrite_rules',
+    static function (string $rules) {
+        $insertion = <<<HTACCESS
+# Add trailing slash if doesn't end with / and doesn't contain a dot
+RewriteCond %{REQUEST_URI} !(\.|/$)
+RewriteRule ^(.+)$ /$1/ [R=301,L]
+
+HTACCESS;
+        $needle = "RewriteEngine On\n";
+        if (strpos($rules, $needle) === false) {
+            return $needle.$insertion.$rules;
+        }
+        return str_replace($needle, $needle.$insertion, $rules);
+    },
+    20,
+    1
+);

--- a/mu-plugins/_core-auto-trailing-slash.php
+++ b/mu-plugins/_core-auto-trailing-slash.php
@@ -7,7 +7,7 @@
 
 add_filter(
     'mod_rewrite_rules',
-    static function (string $rules) {
+    static function ($rules) {
         $insertion = <<<HTACCESS
 # Add trailing slash if URL doesn't contain a dot and doesn't already end with /
 RewriteCond %{REQUEST_URI} !(\.|/$)

--- a/mu-plugins/_core-auto-trailing-slash.php
+++ b/mu-plugins/_core-auto-trailing-slash.php
@@ -9,7 +9,7 @@ add_filter(
     'mod_rewrite_rules',
     static function (string $rules) {
         $insertion = <<<HTACCESS
-# Add trailing slash if doesn't end with / and doesn't contain a dot
+# Add trailing slash if URL doesn't contain a dot and doesn't already end with /
 RewriteCond %{REQUEST_URI} !(\.|/$)
 RewriteRule ^(.+)$ /$1/ [R=301,L]
 


### PR DESCRIPTION
Adds a filter to mod_rewrite_rules to enforce trailing slashes for URLs without dots.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces trailing slashes for paths without dots by injecting an .htaccess rule via the mod_rewrite_rules filter. Requests missing a trailing slash (and with no dot) are 301-redirected to the slash version for canonical URLs and consistent routing.

<sup>Written for commit 934401c5bd876d7673d537069b655a6c0b7055cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

