### PR TITLE
Add plugin to prevent spaces in usernames

### DIFF
--- a/mu-plugins/_core-username.php
+++ b/mu-plugins/_core-username.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * Plugin Name: Prevent space in username
+ * Plugin URI: https://core.trac.wordpress.org/ticket/44690
+ */
+
+add_filter(
+    'sanitize_user',
+    static function($username, $raw_username, $strict) {
+        if ($strict) {
+            return preg_replace('/\s+/', '', $username);
+        }
+        return $username;
+    },
+    10,
+    3
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a must-use plugin that removes spaces (and other whitespace) from usernames during strict `sanitize_user` processing to prevent invalid usernames. Non-strict sanitization is unaffected.

<sup>Written for commit 1ae2feb5658badbf4a9b6108fd01fa8656ae1aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

