### PR TITLE
Create _core-disable-command-palette.php

### DIFF
--- a/mu-plugins/_core-disable-command-palette.php
+++ b/mu-plugins/_core-disable-command-palette.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Plugin Name: Disable command palette
+ * Plugin URI: https://github.com/szepeviktor/wordpress-website-lifecycle
+ */
+
+add_action(
+    'admin_init',
+    static function () {
+        remove_action('admin_enqueue_scripts', 'wp_enqueue_command_palette_assets');
+    },
+    10,
+    0
+);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disables the WordPress admin Command Palette by adding an MU plugin that unhooks `wp_enqueue_command_palette_assets` on `admin_init`. This prevents Command Palette assets from loading in wp-admin for all users.

<sup>Written for commit e0da58a519a507d9ba67012a37ed54b466eab041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

