### PR TITLE
Update Divi theme version to 5.0.0

### DIFF
--- a/divi-child/divi-download.php
+++ b/divi-child/divi-download.php
@@ -11,7 +11,8 @@ $args = [
     'body' => [
         'action' => 'check_theme_updates',
         'class_version' => '1.2',
-        'installed_themes' => ['Divi' => '4.0.0'],
+        'installed_themes' => ['Divi' => '5.0.0'],
+        'divi_5' => 'on',
     ],
 ];
 $response = wp_remote_post('https://www.elegantthemes.com/api/api.php', $args);

--- a/divi-child/style.css
+++ b/divi-child/style.css
@@ -3,7 +3,7 @@
  * Theme URI: https://www.elegantthemes.com/gallery/divi/
  * Description: Divi Child Theme
  * Author: you
- * Author URI: https://example.com/
+ * Author URI: https://www.elegantthemes.com/api/changelog/divi-5.txt
  * Template: Divi
  * Version: 1.0.0
  * Requires at least: 6.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the Divi update check to target Divi 5 by reporting version 5.0.0 and sending the `divi_5=on` flag so it fetches the correct package from Elegant Themes. Also update the child theme’s Author URI to the Divi 5 changelog for quick reference.

<sup>Written for commit 3c246c19a228271d80e0ac3c13b050cf6198111c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

