### PR TITLE
Refactor FluentSMTP settings for menu and email handling

### DIFF
--- a/mu-plugins/fluent-smtp.php
+++ b/mu-plugins/fluent-smtp.php
@@ -5,10 +5,13 @@
  * Plugin URI: https://github.com/szepeviktor/wordpress-website-lifecycle
  */
 
-add_action('fluent_mail_loading_app', static function () {
-    wp_add_inline_script(
-        'fluent_mail_admin_app_boot',
-        <<<'JS'
+// Hide menu items
+add_action(
+    'fluent_mail_loading_app',
+    static function () {
+        wp_add_inline_script(
+            'fluent_mail_admin_app_boot',
+            <<<'JS'
 window.FluentMail.addFilter(
     'fluentmail_top_menus',
     'remove_about_and_documentation',
@@ -19,5 +22,20 @@ window.FluentMail.addFilter(
     }
 );
 JS
-    );
-});
+        );
+    },
+    10,
+    0
+);
+
+// Disable email sending in non-production environments
+add_action(
+    'plugins_loaded',
+    static function () {
+        if (wp_get_environment_type() !== 'production') {
+            define('FLUENTMAIL_SIMULATE_EMAILS', true);
+        }
+    },
+    0,
+    0
+);


### PR DESCRIPTION
Refactor FluentSMTP settings to improve menu item handling and email simulation in non-production environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the “About” and “Documentation” items in the FluentSMTP admin menu and simulate emails outside production to prevent accidental sends by enabling `FLUENTMAIL_SIMULATE_EMAILS`.

<sup>Written for commit 2e0ea8ece91eb007662ac50e78a69403cce04cd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

