### PR TITLE
Block Action Scheduler too

### DIFF
--- a/mu-plugins/_core-migration.php
+++ b/mu-plugins/_core-migration.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Plugin Name: Migration
+ * Plugin Name: Migration source server guard
  * Plugin URI: https://github.com/szepeviktor/wordpress-website-lifecycle
  */
 
@@ -56,12 +56,12 @@ add_action(
             [ActionScheduler::runner(), 'run']
         );
     },
-    10,
+    PHP_INT_MAX,
     0
 );
 add_filter(
     'action_scheduler_allow_async_request_runner',
     '__return_false',
     10,
-    1
+    0
 );

--- a/mu-plugins/_core-migration.php
+++ b/mu-plugins/_core-migration.php
@@ -42,3 +42,26 @@ add_filter(
     PHP_INT_MAX,
     2
 );
+
+// Block Action Scheduler
+add_action(
+    'init',
+    static function () {
+        if (!class_exists('ActionScheduler')) {
+            return;
+        }
+
+        remove_action(
+            'action_scheduler_run_queue',
+            [ActionScheduler::runner(), 'run']
+        );
+    },
+    10,
+    0
+);
+add_filter(
+    'action_scheduler_allow_async_request_runner',
+    '__return_false',
+    10,
+    1
+);


### PR DESCRIPTION
Added action to modify Action Scheduler behavior by removing the default runner and preventing async requests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks background job execution by disabling `ActionScheduler` runners on the source server. Removes the default queue runner from `action_scheduler_run_queue`, forces `action_scheduler_allow_async_request_runner` to false, and renames the MU plugin to `Migration source server guard`.

<sup>Written for commit 124d4719bb0f644e00eb82fa2fef2f83dfa77ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

