### PR TITLE
Add disable-query-vars-parameters

### DIFF
--- a/mu-plugins/_core-disable-query-vars-parameters.php
+++ b/mu-plugins/_core-disable-query-vars-parameters.php
@@ -8,7 +8,7 @@
 // permalink_structure must of enabled
 add_action(
     'parse_request',
-    static function ($wp): {
+    static function ($wp) {
         if (is_admin()) {
             return;
         }

--- a/mu-plugins/_core-disable-query-vars-parameters.php
+++ b/mu-plugins/_core-disable-query-vars-parameters.php
@@ -16,8 +16,12 @@ add_action(
         }
         $whitelist = [
             's', // Search
-            'preview', // Post preview
         ];
+        if (array_key_exists('preview', $_GET) && is_user_logged_in()) {
+            $whitelist[] = 'preview';
+            $whitelist[] = 'p';
+            $whitelist[] = 'page_id';
+        }
         $requested_query_vars = array_intersect(
             array_keys($_GET),
             $wp->public_query_vars

--- a/mu-plugins/_core-disable-query-vars-parameters.php
+++ b/mu-plugins/_core-disable-query-vars-parameters.php
@@ -9,14 +9,24 @@
 add_action(
     'parse_request',
     static function ($wp) {
-        if (is_admin()) {
+        $is_pretty_rest_request = isset($wp->query_vars['rest_route'])
+            && !array_key_exists('rest_route', $_GET);
+        if (is_admin() || $is_pretty_rest_request) {
             return;
         }
+        $whitelist = [
+            's', // Search
+            'preview', // Post preview
+        ];
         $requested_query_vars = array_intersect(
             array_keys($_GET),
             $wp->public_query_vars
         );
-        if ($requested_query_vars !== []) {
+        $blocked_query_vars = array_diff(
+            $requested_query_vars,
+            $whitelist
+        );
+        if ($blocked_query_vars !== []) {
             $wp->query_vars = ['error' => '404'];
         }
     },

--- a/mu-plugins/_core-disable-query-vars-parameters.php
+++ b/mu-plugins/_core-disable-query-vars-parameters.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Plugin Name: Disable query vars parameters
+ * Plugin URI: https://github.com/szepeviktor/wordpress-website-lifecycle
+ */
+
+// permalink_structure must of enabled
+add_action(
+    'parse_request',
+    static function ($wp): {
+        if (is_admin()) {
+            return;
+        }
+        $requested_query_vars = array_intersect(
+            array_keys($_GET),
+            $wp->public_query_vars
+        );
+        if ($requested_query_vars !== []) {
+            $wp->query_vars = ['error' => '404'];
+        }
+    },
+    0,
+    1
+);

--- a/mu-plugins/_core-disable-query-vars-parameters.php
+++ b/mu-plugins/_core-disable-query-vars-parameters.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://github.com/szepeviktor/wordpress-website-lifecycle
  */
 
-// permalink_structure must of enabled
+// permalink_structure must be enabled
 add_action(
     'parse_request',
     static function ($wp) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a mu-plugin that blocks frontend requests containing public query vars by forcing a 404. It runs on `parse_request` at priority 0, skips admin, bypasses pretty REST requests (so `/wp-json` works), and enables logged-in previews by whitelisting `preview`, `p`, and `page_id`; includes a small syntax fix.

<sup>Written for commit dcc2cde5c4db4fbd2c3cf43de5da6a62db5bfcbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

