### PR TITLE
Add access log functionality in debug-access-log.php

### DIFF
--- a/debug/debug-access-log.php
+++ b/debug/debug-access-log.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Insert this snippet at the top of wp-config.php
+ */
+
+// Write an Apache-like access.log
+register_shutdown_function(function () {
+    file_put_contents(dirname(__DIR__).'/access.log', sprintf(
+        '%s - - [%s] "%s %s %s" %d %.2f "%s" "%s"' . PHP_EOL,
+        $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1',
+        date('d/M/Y:H:i:s O'),
+        $_SERVER['REQUEST_METHOD'] ?? 'GET',
+        $_SERVER['REQUEST_URI'] ?? '/',
+        $_SERVER['SERVER_PROTOCOL'] ?? 'HTTP/1.1',
+        http_response_code(),
+        timer_float(),
+        $_SERVER['HTTP_REFERER'] ?? '-',
+        $_SERVER['HTTP_USER_AGENT'] ?? '-'
+    ), FILE_APPEND | LOCK_EX);
+});


### PR DESCRIPTION
This PHP script logs access requests in an Apache-like format to an access.log file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shutdown hook that logs every request in Apache-like format to an `access.log` at the repo root. Captures IP, method, path, protocol, status, render time (`timer_float()`), referrer, and user agent.

- **Migration**
  - Add `require_once __DIR__ . '/debug/debug-access-log.php';` to the top of `wp-config.php`.
  - Ensure the project root is writable so `access.log` can be created.

<sup>Written for commit 6d3cb05ab31290e6c673571cf3e1b23b9c40b7e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

