### PR TITLE
Add filter to prevent wp_gf_feed_processor loopback

### DIFF
--- a/mu-plugins/gravityforms.php
+++ b/mu-plugins/gravityforms.php
@@ -44,6 +44,28 @@ add_filter(
     0
 );
 
+// Prevent wp_gf_feed_processor loopback request.
+add_filter(
+    'gform_entry_post_save',
+    static function ($entry) {
+        add_filter(
+            'pre_http_request',
+            static function ($pre, $args, $url) {
+                parse_str(parse_url($url, PHP_URL_QUERY) ?: '', $query);
+                if (($query['action'] ?? '') !== 'wp_gf_feed_processor') {
+                    return $pre;
+                }
+                return ['response' => ['code' => 200]];
+            },
+            PHP_INT_MAX,
+            3
+        );
+        return $entry;
+    },
+    PHP_INT_MAX,
+    1
+);
+
 // Hide admin tooltips.
 add_filter(
     'gform_tooltips',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents the Gravity Forms wp_gf_feed_processor loopback after an entry is saved to reduce self-HTTP calls and avoid timeouts. Old behavior: a loopback to admin-ajax?action=wp_gf_feed_processor ran after each save. New behavior: the request is intercepted via pre_http_request and returned as HTTP 200 immediately; other HTTP calls are unchanged.

- Scope: only during the request that saves the entry; other requests and endpoints are unaffected.
- Impact: async feed processing via the AJAX endpoint will not run. Verify add-ons that rely on async processing still work (they may process on save).
- Migration: none required. If you need the loopback, remove this filter or guard it by environment.

<sup>Written for commit 8c02bf38669aed021b0b5899e6c1648c983fef51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/szepeviktor/wordpress-website-lifecycle/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

